### PR TITLE
Centering images

### DIFF
--- a/layouts/_default/card.html
+++ b/layouts/_default/card.html
@@ -5,8 +5,8 @@
             {{- $images := . -}}
             {{- with $page.Site.GetPage "section" "images" -}}
                 {{- with .Resources.GetMatch (strings.TrimPrefix "/images/" (index $images 0)) -}}
-                    {{- $image := .Fill "700x350" -}}
-                    <img data-src="{{ $image.RelPermalink }}" class="card-img-top" alt="{{ $page.Title }}">
+                    {{- $image := .Fit "700x350" -}}
+                    <img data-src="{{ $image.RelPermalink }}" class="card-img-top mx-auto d-block" alt="{{ $page.Title }}">
                 {{- end -}}
             {{- end -}}
         {{- end -}}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -22,10 +22,10 @@
                     {{- $images := . -}}
                     {{- with $page.Site.GetPage "section" "images" -}}
                         {{- with .Resources.GetMatch (strings.TrimPrefix "/images/" (index $images 0)) -}}
-                            {{- $image := .Fill "900x500" -}}
+                            {{- $image := .Fit "900x500" -}}
                             <div class="row justify-content-center mb-3">
                                 <div class="col-lg-10">
-                                    <img data-src="{{ $image.RelPermalink }}" class="img-fluid rounded" alt="{{ $page.Title }}">
+                                    <img data-src="{{ $image.RelPermalink }}" class="img-fluid rounded mx-auto d-block" alt="{{ $page.Title }}">
                                 </div>
                             </div>
                         {{- end -}}


### PR DESCRIPTION
Not sure if you want to adopt this or not but I wanted the images centered on the Card and the Post layouts without cutting the image off. I changed Fill to Fit to auto-scale the image to fit in the container then added the class "mx-auto d-block" to center them within the container.