### PR TITLE
Multilingual hyperlink support

### DIFF
--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,0 +1,12 @@
+# Single
+wordCount:
+    one: "{{ .Count }} letter"
+    other: "{{ .Count }} letters"
+
+readingTime:
+    one: "{{ .Count }} min read"
+    other: "{{ .Count }} mins read"
+
+# Author
+articles:
+    other: "Articles"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
         </button>
         <div class="collapse navbar-collapse" id="main-menu">
             <ul class="navbar-nav ml-auto">
-			{{ partial "i18nlist.html" . }}
+            {{ partial "i18nlist.html" . }}
             {{ with .Site.Menus.main }}
                 {{ range . }}
                     <li class="nav-item{{ if $current.IsMenuCurrent "main" . }} active{{ end }}"><a class="nav-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,13 +6,14 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="main-menu">
-            {{ with .Site.Menus.main }}
             <ul class="navbar-nav ml-auto">
+			{{ partial "i18nlist.html" . }}
+            {{ with .Site.Menus.main }}
                 {{ range . }}
                     <li class="nav-item{{ if $current.IsMenuCurrent "main" . }} active{{ end }}"><a class="nav-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a></li>
                 {{ end }}
-            </ul>
             {{ end }}
+            </ul>
         </div>
     </div>
 </nav>

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -1,0 +1,6 @@
+{{ if .IsTranslated }}
+    {{ range .Translations }}
+	<li class="nav-item"><a class="nav-link" href="{{ .Permalink }}">{{ .Lang }}</a>
+    </li>
+    {{ end}}
+{{ end }}


### PR DESCRIPTION
I have implemented a simple feature to give functionality of multilingual hyperlinks.

When you specify languages configuration such as the following, you will get hyperlinks to other languages at the upper right corner.

```
[languages]
  [languages.en]
    languageName = "English"
    title = "English Title"
    weight = 1
  [languages.ja]
    languageName = "Japanese"
    title = "Japanese Title"
    weight = 2
```

![Screenshot_2020-01-04_13-34-38](https://user-images.githubusercontent.com/1498450/71766529-9f716f80-2ef8-11ea-934b-131bfae25fbf.png)
