### PR TITLE
Change card.html to unescape html characters

### DIFF
--- a/layouts/_default/card.html
+++ b/layouts/_default/card.html
@@ -14,7 +14,7 @@
             <h4 class="card-title">{{ $page.Title }}</h4>
             <p class="card-text text-muted text-uppercase">{{ $page.Date.Format "January 2, 2006" }}</p>
             <div class="card-text">
-                {{ $page.Summary | plainify }}
+                {{ $page.Summary }}
             </div>
         </div>
     </a>

--- a/layouts/_default/card.html
+++ b/layouts/_default/card.html
@@ -14,7 +14,7 @@
             <h4 class="card-title">{{ $page.Title }}</h4>
             <p class="card-text text-muted text-uppercase">{{ $page.Date.Format "January 2, 2006" }}</p>
             <div class="card-text">
-                {{ $page.Summary }}
+                {{ $page.Summary | htmlUnescape }}
             </div>
         </div>
     </a>

--- a/layouts/_default/card.html
+++ b/layouts/_default/card.html
@@ -5,7 +5,7 @@
             {{- $images := . -}}
             {{- with $page.Site.GetPage "section" "images" -}}
                 {{- with .Resources.GetMatch (strings.TrimPrefix "/images/" (index $images 0)) -}}
-                    {{- $image := .Resize "700x350" -}}
+                    {{- $image := .Fill "700x350" -}}
                     <img data-src="{{ $image.RelPermalink }}" class="card-img-top mx-auto d-block" alt="{{ $page.Title }}">
                 {{- end -}}
             {{- end -}}


### PR DESCRIPTION
In the posts cards (the summary of blog posts) `plainify` doesn't properly escape the HTML so characters like double-quotes ("") are displayed as `&ldquo;` [image](https://imgur.com/jUTtXwk).

Changing to `htmlUnescape` resolves this problem