### PR TITLE
Ensure that text with html attributes in it is cleaned

### DIFF
--- a/layouts/_default/card.html
+++ b/layouts/_default/card.html
@@ -14,7 +14,7 @@
             <h4 class="card-title">{{ $page.Title }}</h4>
             <p class="card-text text-muted text-uppercase">{{ $page.Date.Format (.Site.Params.dateFormat | default "January 2, 2006" ) }}</p>
             <div class="card-text">
-                {{ $page.Summary | htmlUnescape }}
+                {{ $page.Summary | plainify | htmlUnescape }}
             </div>
         </div>
     </a>


### PR DESCRIPTION
If you have a link or other attribute in the summary section of posts the html tags will appear in raw form in the card displayed on the lists page.